### PR TITLE
raft.go: simplify checking for majority of votes

### DIFF
--- a/part1/raft.go
+++ b/part1/raft.go
@@ -300,7 +300,7 @@ func (cm *ConsensusModule) startElection() {
 				} else if reply.Term == savedCurrentTerm {
 					if reply.VoteGranted {
 						votes := int(atomic.AddInt32(&votesReceived, 1))
-						if votes*2 > len(cm.peerIds)+1 {
+						if votes >= len(cm.peerIds)/2+1 {
 							// Won the election!
 							cm.dlog("wins election with %d votes", votes)
 							cm.startLeader()

--- a/part2/raft.go
+++ b/part2/raft.go
@@ -406,7 +406,7 @@ func (cm *ConsensusModule) startElection() {
 				} else if reply.Term == savedCurrentTerm {
 					if reply.VoteGranted {
 						votes := int(atomic.AddInt32(&votesReceived, 1))
-						if votes*2 > len(cm.peerIds)+1 {
+						if votes >= len(cm.peerIds)/2+1 {
 							// Won the election!
 							cm.dlog("wins election with %d votes", votes)
 							cm.startLeader()

--- a/part3/raft.go
+++ b/part3/raft.go
@@ -502,7 +502,7 @@ func (cm *ConsensusModule) startElection() {
 				} else if reply.Term == savedCurrentTerm {
 					if reply.VoteGranted {
 						votes := int(atomic.AddInt32(&votesReceived, 1))
-						if votes*2 > len(cm.peerIds)+1 {
+						if votes >= len(cm.peerIds)/2+1 {
 							// Won the election!
 							cm.dlog("wins election with %d votes", votes)
 							cm.startLeader()


### PR DESCRIPTION
I was looking how Raft would deal with split-votes. It split-votes can't occur forever because of randomized timeouts. At some point a candidate with a shorter timeout will receive votes from a majority of the servers in the full cluster and then becomes the leader. 

But what means majority? Obviously it means more than half of the servers, which is mathematically `majority >= floor(n/2) + 1` (where `n` is the number of servers in the full cluster). 

I thought rewriting the if clause that represents the mathematical  notation would make it easier for the reader to understand how we check for the majority of the votes. Because integer divisions in Go already perform floor division, we only need to make a small change.

All the tests are passing this change, so it should be good to merge:

```zsh
$ for x (part1 part2 part3); do echo "Testing ${x} ..." && pushd $x && go test ./... && popd; done
Testing part1 ...
ok      github.com/eliben/raft  8.656s
Testing part2 ...
ok      github.com/eliben/raft  15.168s
Testing part3 ...
ok      github.com/eliben/raft  26.035s
```