### PR TITLE
raft.go: remove atomic increment on votesReveived

### DIFF
--- a/part1/raft.go
+++ b/part1/raft.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -271,7 +270,7 @@ func (cm *ConsensusModule) startElection() {
 	cm.votedFor = cm.id
 	cm.dlog("becomes Candidate (currentTerm=%d); log=%v", savedCurrentTerm, cm.log)
 
-	var votesReceived int32 = 1
+	votesReceived := 1
 
 	// Send RequestVote RPCs to all other servers concurrently.
 	for _, peerId := range cm.peerIds {
@@ -299,10 +298,10 @@ func (cm *ConsensusModule) startElection() {
 					return
 				} else if reply.Term == savedCurrentTerm {
 					if reply.VoteGranted {
-						votes := int(atomic.AddInt32(&votesReceived, 1))
-						if votes*2 > len(cm.peerIds)+1 {
+						votesReceived += 1
+						if votesReceived*2 > len(cm.peerIds)+1 {
 							// Won the election!
-							cm.dlog("wins election with %d votes", votes)
+							cm.dlog("wins election with %d votes", votesReceived)
 							cm.startLeader()
 							return
 						}

--- a/part2/raft.go
+++ b/part2/raft.go
@@ -10,7 +10,6 @@ import (
 	"math/rand"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -371,7 +370,7 @@ func (cm *ConsensusModule) startElection() {
 	cm.votedFor = cm.id
 	cm.dlog("becomes Candidate (currentTerm=%d); log=%v", savedCurrentTerm, cm.log)
 
-	var votesReceived int32 = 1
+	votesReceived := 1
 
 	// Send RequestVote RPCs to all other servers concurrently.
 	for _, peerId := range cm.peerIds {
@@ -405,10 +404,10 @@ func (cm *ConsensusModule) startElection() {
 					return
 				} else if reply.Term == savedCurrentTerm {
 					if reply.VoteGranted {
-						votes := int(atomic.AddInt32(&votesReceived, 1))
-						if votes*2 > len(cm.peerIds)+1 {
+						votesReceived += 1
+						if votesReceived*2 > len(cm.peerIds)+1 {
 							// Won the election!
-							cm.dlog("wins election with %d votes", votes)
+							cm.dlog("wins election with %d votes", votesReceived)
 							cm.startLeader()
 							return
 						}

--- a/part3/raft.go
+++ b/part3/raft.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"os"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
@@ -467,7 +466,7 @@ func (cm *ConsensusModule) startElection() {
 	cm.votedFor = cm.id
 	cm.dlog("becomes Candidate (currentTerm=%d); log=%v", savedCurrentTerm, cm.log)
 
-	var votesReceived int32 = 1
+	votesReceived := 1
 
 	// Send RequestVote RPCs to all other servers concurrently.
 	for _, peerId := range cm.peerIds {
@@ -501,10 +500,10 @@ func (cm *ConsensusModule) startElection() {
 					return
 				} else if reply.Term == savedCurrentTerm {
 					if reply.VoteGranted {
-						votes := int(atomic.AddInt32(&votesReceived, 1))
-						if votes*2 > len(cm.peerIds)+1 {
+						votesReceived += 1
+						if votesReceived*2 > len(cm.peerIds)+1 {
 							// Won the election!
-							cm.dlog("wins election with %d votes", votes)
+							cm.dlog("wins election with %d votes", votesReceived)
 							cm.startLeader()
 							return
 						}


### PR DESCRIPTION
because votesReceived is changed and read in the block which protected by cm.mu, I think atomic increment is unnecessary