### PR TITLE
Add a fix for a potential leader heartbeat race.

### DIFF
--- a/part3/raft.go
+++ b/part3/raft.go
@@ -573,6 +573,7 @@ func (cm *ConsensusModule) startLeader() {
 			}
 
 			if doSend {
+				// If this isn't a leader any more, stop the heartbeat loop.
 				cm.mu.Lock()
 				if cm.state != Leader {
 					cm.mu.Unlock()
@@ -589,6 +590,10 @@ func (cm *ConsensusModule) startLeader() {
 // replies and adjusts cm's state.
 func (cm *ConsensusModule) leaderSendAEs() {
 	cm.mu.Lock()
+	if cm.state != Leader {
+		cm.mu.Unlock()
+		return
+	}
 	savedCurrentTerm := cm.currentTerm
 	cm.mu.Unlock()
 


### PR DESCRIPTION
The heartbeat loop invokes leaderSendAEs without holding cm.mu, so in the
mean-time this node may have become a follower, and shouldn't be sending
heartbeats.

For #13