### PR TITLE
remove goroutine for-loop index capture

### DIFF
--- a/part1/raft.go
+++ b/part1/raft.go
@@ -274,7 +274,7 @@ func (cm *ConsensusModule) startElection() {
 
 	// Send RequestVote RPCs to all other servers concurrently.
 	for _, peerId := range cm.peerIds {
-		go func(peerId int) {
+		go func() {
 			args := RequestVoteArgs{
 				Term:        savedCurrentTerm,
 				CandidateId: cm.id,
@@ -308,7 +308,7 @@ func (cm *ConsensusModule) startElection() {
 					}
 				}
 			}
-		}(peerId)
+		}()
 	}
 
 	// Run another election timer, in case this election is not successful.
@@ -368,7 +368,7 @@ func (cm *ConsensusModule) leaderSendHeartbeats() {
 			Term:     savedCurrentTerm,
 			LeaderId: cm.id,
 		}
-		go func(peerId int) {
+		go func() {
 			cm.dlog("sending AppendEntries to %v: ni=%d, args=%+v", peerId, 0, args)
 			var reply AppendEntriesReply
 			if err := cm.server.Call(peerId, "ConsensusModule.AppendEntries", args, &reply); err == nil {
@@ -380,6 +380,6 @@ func (cm *ConsensusModule) leaderSendHeartbeats() {
 					return
 				}
 			}
-		}(peerId)
+		}()
 	}
 }

--- a/part2/raft.go
+++ b/part2/raft.go
@@ -374,7 +374,7 @@ func (cm *ConsensusModule) startElection() {
 
 	// Send RequestVote RPCs to all other servers concurrently.
 	for _, peerId := range cm.peerIds {
-		go func(peerId int) {
+		go func() {
 			cm.mu.Lock()
 			savedLastLogIndex, savedLastLogTerm := cm.lastLogIndexAndTerm()
 			cm.mu.Unlock()
@@ -414,7 +414,7 @@ func (cm *ConsensusModule) startElection() {
 					}
 				}
 			}
-		}(peerId)
+		}()
 	}
 
 	// Run another election timer, in case this election is not successful.
@@ -475,7 +475,7 @@ func (cm *ConsensusModule) leaderSendHeartbeats() {
 	cm.mu.Unlock()
 
 	for _, peerId := range cm.peerIds {
-		go func(peerId int) {
+		go func() {
 			cm.mu.Lock()
 			ni := cm.nextIndex[peerId]
 			prevLogIndex := ni - 1
@@ -535,7 +535,7 @@ func (cm *ConsensusModule) leaderSendHeartbeats() {
 					}
 				}
 			}
-		}(peerId)
+		}()
 	}
 }
 

--- a/part3/raft/raft.go
+++ b/part3/raft/raft.go
@@ -480,7 +480,7 @@ func (cm *ConsensusModule) startElection() {
 
 	// Send RequestVote RPCs to all other servers concurrently.
 	for _, peerId := range cm.peerIds {
-		go func(peerId int) {
+		go func() {
 			cm.mu.Lock()
 			savedLastLogIndex, savedLastLogTerm := cm.lastLogIndexAndTerm()
 			cm.mu.Unlock()
@@ -520,7 +520,7 @@ func (cm *ConsensusModule) startElection() {
 					}
 				}
 			}
-		}(peerId)
+		}()
 	}
 
 	// Run another election timer, in case this election is not successful.
@@ -608,7 +608,7 @@ func (cm *ConsensusModule) leaderSendAEs() {
 	cm.mu.Unlock()
 
 	for _, peerId := range cm.peerIds {
-		go func(peerId int) {
+		go func() {
 			cm.mu.Lock()
 			ni := cm.nextIndex[peerId]
 			prevLogIndex := ni - 1
@@ -697,7 +697,7 @@ func (cm *ConsensusModule) leaderSendAEs() {
 					cm.mu.Unlock()
 				}
 			}
-		}(peerId)
+		}()
 	}
 }
 


### PR DESCRIPTION
As per [Go 1.22](https://go.dev/blog/loopvar-preview), this is unnecessary.